### PR TITLE
Check deletioninprogress to skip activities deleted in the course

### DIFF
--- a/classes/lib.php
+++ b/classes/lib.php
@@ -54,6 +54,11 @@ class lib {
         // Add plagiarism and feedback status.
         $assignments = [];
         foreach ($assigns as $cm) {
+            // Skip activities deleted in the course.
+            $rec = $cm->get_course_module_record();
+            if ($rec->deletioninprogress) {
+                continue;
+            }
             $context = \context_module::instance($cm->id);
             $assignment = new \assign($context, $cm, $course);
             $instance = $assignment->get_instance();


### PR DESCRIPTION
When a teacher deletes one of the assignments in the course, the report still displays removed elements.

The reason for that is inside report_assign\lib::get_assignments() function.
All course_module instances are iterated over, not taking into account their deletioninprogress property.

Proposed solution is to check deletioninprogress to skip activities deleted in the course.