### PR TITLE
Fixing header name for grader column in exportall function

### DIFF
--- a/classes/lib.php
+++ b/classes/lib.php
@@ -886,7 +886,7 @@ class lib {
         if ($isturnitin) {
             $myxls->write_string(1, $i++, get_string('turnitin', 'report_assign'));
         }
-        $myxls->write_string(1, $i++, get_string('allocatedmarker', 'report_assign'));
+        $myxls->write_string(1, $i++, get_string('grader', 'report_assign'));
         $myxls->write_string(1, $i++, get_string('modified'));
         $myxls->write_string(1, $i++, get_string('duedate', 'report_assign'));
         $myxls->write_string(1, $i++, get_string('extension', 'report_assign'));


### PR DESCRIPTION
Hello,
There is a typo in the `exportall` method from the lib class. The grader is displayed for each submission (if there is one) but the header displays the `allocatedmarker` string.