### PR TITLE
Workflow values are now translated via Moodle mod_assign strings

### DIFF
--- a/classes/lib.php
+++ b/classes/lib.php
@@ -488,7 +488,7 @@ class lib {
         $workflow = '-';
         $marker = '-';
         if (!empty($userflags)) {
-            $workflow = empty($userflags->workflowstate) ? '-' : $userflags->workflowstate;
+            $workflow = empty($userflags->workflowstate) ? '-' : get_string('markingworkflowstate' . $userflags->workflowstate, 'mod_assign');
             if ($userflags->allocatedmarker) {
                 if ($user = $DB->get_record('user', ['id' => $userflags->allocatedmarker])) {
                     $marker = fullname($user);


### PR DESCRIPTION
Hello,

Workflow value (if applicable) is displayed as it is stored in the DB, meaning in lowercase and untranslated. This fixes that issue.