### PR TITLE
Adding workflow and marker to exportall

### DIFF
--- a/classes/lib.php
+++ b/classes/lib.php
@@ -887,10 +887,10 @@ class lib {
             $myxls->write_string(1, $i++, get_string('turnitin', 'report_assign'));
         }
         $hasworflow = array_reduce($submissions, function($c, $it) {
-            return $c === true ? true : $it->workflow !== '-';
+            return $c || $it->workflow !== '-';
         }, false);
         $hasmarker = array_reduce($submissions, function($c, $it) {
-            return $c === true ? true : $it->marker !== '-';
+            return $c || $it->marker !== '-';
         }, false);
         if($hasworflow) {
             $myxls->write_string(1, $i++, get_string('workflow', 'report_assign'));


### PR DESCRIPTION
Hello,

The `export` method in lib class for a single assignment adds workflow and marker columns if they are enable for the assignment.
That is not the case for `exportall`. This PR adds that feature. These columns are only added if at least one submission has workflow and/or marker.